### PR TITLE
Do not implode recipient query status filter when setting attribute r…

### DIFF
--- a/src/Service/V1/Api/Recipients/Recipient/Parameter/RecipientQueryParam.php
+++ b/src/Service/V1/Api/Recipients/Recipient/Parameter/RecipientQueryParam.php
@@ -151,10 +151,6 @@ class RecipientQueryParam extends GenericParameter
     public function setStatus($status)
     {
 
-        if (is_array($status)) {
-            $status = implode(',', $status);
-        }
-
         $this->setAttributeRaw('status', $status);
 
         return $this;


### PR DESCRIPTION
…aw value as the API expects it as an array rather than CSV-string (Fixes #1)