### PR TITLE
Avoid Deprecation message

### DIFF
--- a/src/Http/ThrottleMiddleware.php
+++ b/src/Http/ThrottleMiddleware.php
@@ -107,7 +107,7 @@ class ThrottleMiddleware
         if (count($this->timestampStack) >= $this->requestsPerInterval) {
 
             usleep(
-                abs(
+                (int) abs(
                     min($now - $this->timestampStack[0] - $this->interval, 0)
                 ) * 1000000
             );


### PR DESCRIPTION
This avoids an INFO log message:

Deprecated: Implicit conversion from float XXX to int loses precision

Which is thrown in src/Http/ThrottleMiddleware.php:112

Trace:

```
Message
Deprecated: Implicit conversion from float 6280.8990478515625 to int loses precision
Level
INFO
Exception
{
    "class": "ErrorException",
    "message": "Deprecated: Implicit conversion from float 6280.8990478515625 to int loses precision",
    "code": 0,
    "file": "/application/vendor/rapidmail/rapidmail-apiv3-client-php/src/Http/ThrottleMiddleware.php:112",
    "trace": [
        "/application/vendor/rapidmail/rapidmail-apiv3-client-php/src/Http/ThrottleMiddleware.php:79",
        "/application/vendor/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php:64",
        "/application/vendor/guzzlehttp/guzzle/src/Middleware.php:31",
        "/application/vendor/guzzlehttp/guzzle/src/RedirectMiddleware.php:71",
        "/application/vendor/guzzlehttp/guzzle/src/Middleware.php:66",
        "/application/vendor/guzzlehttp/guzzle/src/HandlerStack.php:75",
        "/application/vendor/guzzlehttp/guzzle/src/Client.php:333",
        "/application/vendor/guzzlehttp/guzzle/src/Client.php:169",
        "/application/vendor/guzzlehttp/guzzle/src/Client.php:189",
        "/application/vendor/rapidmail/rapidmail-apiv3-client-php/src/Http/HttpClientFacade.php:34",
        "/application/vendor/rapidmail/rapidmail-apiv3-client-php/src/Service/V1/Api/Recipients/Recipient/RecipientService.php:240",
        "/application/vendor/rapidmail/rapidmail-apiv3-client-php/src/Service/V1/Api/Recipients/Recipient/RecipientService.php:137",
```