### PR TITLE
Allow psr/http-message 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-json": "*",
         "ext-fileinfo": "*",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^7.0 || ^9.0",


### PR DESCRIPTION
Updating `psr/http-message` to v2 allows easier integration with projects that are already using that dependency.
Compared to v1, it comes with return types which should not be an issue here, as the interfaces from that package are not implemented here.

See: https://github.com/php-fig/http-message/releases/tag/2.0