### PR TITLE
Update HttpClientFactory.php

### DIFF
--- a/src/Http/HttpClientFactory.php
+++ b/src/Http/HttpClientFactory.php
@@ -26,10 +26,13 @@ class HttpClientFactory
             ), 'throttle'
         );
 
+        $version = $config['version'];
+        unset($config['version']);
+
         $clientConfig = array_replace_recursive(
             $config,
             [
-                'base_uri' => rtrim($config['base_uri'], '/') . '/' . $config['version'] . '/',
+                'base_uri' => rtrim($config['base_uri'], '/') . '/' . $version . '/',
                 'handler' => $stack,
                 RequestOptions::HEADERS => [
                     'Accept' => 'application/json',


### PR DESCRIPTION
Prevent the service endpoint version from passing through to curl and being used as the HTTP version and provoking an exception such as "HTTP/v1 is not supported by the cURL handler". See [this issue](https://github.com/rapidmail/rapidmail-apiv3-client-php/issues/21).